### PR TITLE
Support dbt 1.3

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -20,6 +20,8 @@ jobs:
             pip-requirements: "requirements-1.1.txt"
           - python-version: "3.10"
             pip-requirements: "requirements-1.2.txt"
+          - python-version: "3.10"
+            pip-requirements: "requirements-1.3.txt"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,8 +15,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
-        pip-requirements: ["requirements-1.1.txt", "requirements-1.2.txt"]
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+        pip-requirements:
+          - "requirements-1.1.txt"
+          - "requirements-1.2.txt"
+          - "requirements-1.3.txt"
     defaults:
       run:
         shell: bash

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -1,9 +1,9 @@
 setup:
-	pip install -r requirements/requirements-1.1.txt
+	pip install -r requirements/requirements-1.3.txt
 	dbt deps --profiles-dir profiles --target bigquery
 
 generate:
-	bash scripts/generate_secured_models.sh --vars-path ./resources/vars/vars-bigquery.basic.yml --target bigquery
+	bash -x scripts/generate_secured_models.sh --vars-path ./resources/vars/vars-bigquery.basic.yml --target bigquery
 
 run-unit-tests:
 	bash run_unit_tests.sh --target bigquery --vars-path resources/vars/vars-bigquery.basic.yml

--- a/integration_tests/requirements/requirements-1.3.txt
+++ b/integration_tests/requirements/requirements-1.3.txt
@@ -1,0 +1,2 @@
+dbt-bigquery==1.3.0
+dbt-core==1.3.0

--- a/macros/codegen/generate_privacy_protected_model.sql
+++ b/macros/codegen/generate_privacy_protected_model.sql
@@ -22,7 +22,7 @@
     {% set where = data_privacy_meta.get("where") | default(none, True) %}
 
     {% set data_privacy_config = dbt_data_privacy.get_data_privacy_config_by_objective(objective) %}
-    {% set default_materialization = dbt_data_privacy.get_default_materialization(data_privacy_config) %}
+    {% set default_materialization = dbt_data_privacy.get_default_materialized_config(data_privacy_config) %}
 
     {% set model_config = dbt_data_privacy.format_model_config(**model_config) %}
     {% set enabled = model_config.get("enabled") %}

--- a/macros/system/get_default_materialization.sql
+++ b/macros/system/get_default_materialization.sql
@@ -1,4 +1,4 @@
-{% macro get_default_materialization(data_privacy_config) %}
+{% macro get_default_materialized_config(data_privacy_config) %}
   {% if "default_materialization" not in data_privacy_config %}
     {{ exceptions.raise_compiler_error("'default_materialization' doesn't exist in {}".format(data_privacy_config)) }}
   {% endif %}


### PR DESCRIPTION
## Overview
- Support the new version dbt 1.3.0!
- Rename a macro whose name contains `materialization`.

```bash
Compilation Error
  No supported_languages found in materialization macro dbt_macro__get_default_data_privacy_materialization
```
