### PR TITLE
Support docs config

### DIFF
--- a/integration_tests/macros/tests/codegen/test_format_model_config.sql
+++ b/integration_tests/macros/tests/codegen/test_format_model_config.sql
@@ -35,6 +35,7 @@
         "relation": true,
         "columns": true
       },
+      "docs": none,
       "full_refresh": none,
       "enabled": true,
       "adapter_config": {

--- a/integration_tests/macros/tests/codegen/test_generate_privacy_protected_model_sql.sql
+++ b/integration_tests/macros/tests/codegen/test_generate_privacy_protected_model_sql.sql
@@ -3,23 +3,6 @@
 {% endmacro %}
 
 {% macro bigquery__test_generate_privacy_protected_model_sql() %}
-  {% set model_config = dbt_data_privacy.format_model_config(
-        materialized="view",
-        database="data-analysis-project",
-        schema="test_dataset",
-        alias="test_privacy_protected_users",
-        grant_access_to=[
-          {"project": "test-project1", "dataset": "test_dataset1"},
-          {"project": "test-project2", "dataset": "test_dataset2"},
-        ],
-        tags=["tag1"],
-        labels={
-          "key1": "value1",
-          "key2": "value2",
-        },
-        require_partition_filter=true,
-        partition_expiration_days=7
-    ) %}
   {%- set result = dbt_data_privacy.generate_privacy_protected_model_sql(
       objective="data_analysis",
       materialized="view",
@@ -31,6 +14,7 @@
         "key1": "value1",
         "key2": "value2",
       },
+      docs={"node_color": "red"},
       adapter_config={
         "grant_access_to": [
           {"project": "test-project1", "dataset": "test_dataset1"},
@@ -134,6 +118,7 @@
     },
     re_data_monitored="True",
     persist_docs={'relation': True, 'columns': True},
+    docs={'node_color':'red'},
     full_refresh=None,
     enabled=True
   )

--- a/macros/codegen/format_model_config.sql
+++ b/macros/codegen/format_model_config.sql
@@ -7,8 +7,13 @@
     labels={},
     persist_docs={"relation": true, "columns": true},
     full_refresh=none,
+    docs=none,
     enabled=true
   ) %}
+
+  {%- if docs is not none and docs is not mapping %}
+    {{ exceptions.raise_compiler_error("the 'docs' parameter must be a map {}".format(docs)) }}
+  {%- endif %}
 
   {% set configurations = {
       "materialized": materialized,
@@ -20,6 +25,7 @@
       "persist_docs": persist_docs,
       "full_refresh": full_refresh,
       "enabled": enabled,
+      "docs": docs,
       "adapter_config": {},
       "unknown_config": {},
     } %}

--- a/macros/codegen/generate_privacy_protected_model_sql.sql
+++ b/macros/codegen/generate_privacy_protected_model_sql.sql
@@ -13,9 +13,11 @@
     tags=[],
     labels={},
     persist_docs={"relation": true, "columns": true},
+    docs=none,
     enabled=True,
     full_refresh=none
   ) %}
+
   {{- return(adapter.dispatch('generate_privacy_protected_model_sql', 'dbt_data_privacy')(
       objective=objective,
       materialized=materialized,
@@ -25,6 +27,7 @@
       tags=tags,
       labels=labels,
       persist_docs=persist_docs,
+      docs=docs,
       adapter_config=adapter_config,
       unknown_config=unknown_config,
       reference=reference,
@@ -50,6 +53,7 @@
     tags=[],
     labels={},
     persist_docs={"relation": true, "columns": true},
+    docs=none,
     relationships=none,
     enabled=True,
     full_refresh=none
@@ -109,6 +113,9 @@
     {{ k }}={{ dbt_data_privacy.safe_quote(v) }},
     {%- endfor %}
     persist_docs={{ persist_docs }},
+    {%- if docs is not none and docs is mapping %}
+    docs=docs,
+    {%- endif %}
     full_refresh={{ full_refresh }},
     enabled={{ enabled }}
   )

--- a/macros/codegen/generate_privacy_protected_model_sql.sql
+++ b/macros/codegen/generate_privacy_protected_model_sql.sql
@@ -114,7 +114,7 @@
     {%- endfor %}
     persist_docs={{ persist_docs }},
     {%- if docs is not none and docs is mapping %}
-    docs=docs,
+    docs={{ docs }},
     {%- endif %}
     full_refresh={{ full_refresh }},
     enabled={{ enabled }}


### PR DESCRIPTION
## Overview
dbt 1.3 supports custom node colors. So, dbt-data-privacy explicitly support the config.