### PR TITLE
Test with dbt-core 1.3.1

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,9 @@ on:
       - macros/**/*
       - integration_tests/macros/**/*.sql
       - integration_tests/models/**/*.sql
+      - integration_tests/dbt_package.yml
+      - integration_tests/packages.yml
+      - integration_tests/requirements/*
 
 jobs:
   bigquery:

--- a/integration_tests/requirements/requirements-1.3.txt
+++ b/integration_tests/requirements/requirements-1.3.txt
@@ -1,2 +1,2 @@
 dbt-bigquery==1.3.0
-dbt-core==1.3.0
+dbt-core==1.3.1


### PR DESCRIPTION
## Overview
We check unit tests with dbt-core 1.3.1, instead of dbt-core 1.3.0.