### PR TITLE
Remove an unused alias

### DIFF
--- a/integration_tests/macros/tests/codegen/test_generate_privacy_protected_model_sql.sql
+++ b/integration_tests/macros/tests/codegen/test_generate_privacy_protected_model_sql.sql
@@ -151,7 +151,7 @@ WITH privacy_protected_model AS (
     dummy_array AS `dummy_array`,
     dummy_record AS `dummy_record`,
   FROM
-    {{ ref('test_restricted_users') }} AS __original_table
+    {{ ref('test_restricted_users') }}
   WHERE
     1 = 1
 )

--- a/macros/codegen/generate_privacy_protected_model_sql.sql
+++ b/macros/codegen/generate_privacy_protected_model_sql.sql
@@ -135,9 +135,9 @@ WITH privacy_protected_model AS (
     {%- endfor %}
   FROM
     {%- if dbt_data_privacy.is_macro_expression(reference) %}
-    {{ '{{ ' ~ reference ~ ' }}'}} AS __original_table
+    {{ '{{ ' ~ reference ~ ' }}'}}
     {%- else %}
-    {{ reference }} AS __original_table
+    {{ reference }}
     {%- endif %}
   {%- if where is not none %}
   WHERE


### PR DESCRIPTION
The unused alias causes the sqlfluff violation.

```
L:  34 | P: 101 | AL05 | Alias '__original_table' is never used in SELECT
                       | statement. [aliasing.unused]
```