### PR TITLE
Remove unused test

### DIFF
--- a/integration_tests/macros/tests/codegen/test_generate_secured_model_schema_v2.sql
+++ b/integration_tests/macros/tests/codegen/test_generate_secured_model_schema_v2.sql
@@ -84,10 +84,6 @@ models:
     meta:
       key1: value1
       key2: value2
-    tests:
-      # The test enables us to show the schema YAML file to delete before re-generating the file.
-      # A schema YAML file doesn't appear by `dbt ls --output path`, when it contains no tests.
-      - dbt_data_privacy.dummy_test
     columns:
       - name: consents.data_analysis
         description: |-

--- a/macros/codegen/generate_secured_model_schema_v2.sql
+++ b/macros/codegen/generate_secured_model_schema_v2.sql
@@ -62,11 +62,6 @@ models:
       {{ k }}: {{ v }}
     {%- endfor %}
     {%- endif %}
-    tests:
-      # The test enables us to show the schema YAML file to delete before re-generating the file.
-      # A schema YAML file doesn't appear by `dbt ls --output path`, when it contains no tests.
-      - dbt_data_privacy.dummy_test
-
     {%- if columns | length > 0 %}
     columns: {%- for column_name, column in flatten_columns | dictsort %}
       - name: {{ column.name }}


### PR DESCRIPTION
## Overview
We no longer plan to use the dummy test, as we came up with an alternative idea to identify non-maintained generated models.