### PR TITLE
Support `data_tests`

### DIFF
--- a/integration_tests/macros/tests/codegen/test_generate_secured_model_schema_v2.sql
+++ b/integration_tests/macros/tests/codegen/test_generate_secured_model_schema_v2.sql
@@ -17,6 +17,11 @@
           "meta": {
             "data_privacy": {
               "level": "internal",
+              "test_project__test_dataset__test_table": {
+                "data_tests": [
+                  "unique"
+                ],
+              },
             },
           },
         },
@@ -109,13 +114,15 @@ models:
         meta:
           data_privacy:
             level: internal
+        data_tests:
+          - unique
       - name: user_id
         description: |-
           User ID
         meta:
           data_privacy:
             level: internal
-        tests:
+        data_tests:
           - not_null
 {%- endraw -%}
   {%- endset %}

--- a/macros/codegen/generate_secured_model_schema_v2.sql
+++ b/macros/codegen/generate_secured_model_schema_v2.sql
@@ -76,12 +76,18 @@ models:
             {#- Think of the downgraded data security level #}
             level: {{ column.meta.data_privacy.level }}
         {%- endif %}
+        {#- We support both `data_tests` and `tests` for a while -#}
+        {#- TODO: remove `tests` after dbt no longer supports it -#}
         {%- if 'data_privacy' in column.meta
             and name in column.meta.data_privacy
-            and 'tests' in column.meta.data_privacy[name]
-            and column.meta.data_privacy[name].tests | length > 0 %}
-        tests: {%- for test in column.meta.data_privacy[name].tests %}
-          - {{ test }}
+            and (
+              column.meta.data_privacy[name].get('data_tests', []) | length > 0
+              or column.meta.data_privacy[name].get('tests', []) | length > 0
+            ) %}
+        {%- set data_tests = column.meta.data_privacy[name].get('data_tests', [])
+            + column.meta.data_privacy[name].get('tests', []) %}
+        data_tests: {%- for data_test in data_tests %}
+          - {{ data_test }}
         {%- endfor %}
         {%- endif %}
     {%- endfor %}


### PR DESCRIPTION
## Overview

> New data_tests: syntax
> Data tests were historically called "tests" in dbt as the only form of testing available. With the introduction of unit tests in v1.8, it was necessary to update our naming conventions and syntax.
> As of v1.8, tests: is still supported in your YML configuration files as an alias but will be deprecated in the future in favor of data_tests:.

https://docs.getdbt.com/docs/build/data-tests