### PR TITLE
Improve get_tags_by_original_file_paths.sql

### DIFF
--- a/macros/public/get_tags_by_original_file_paths.sql
+++ b/macros/public/get_tags_by_original_file_paths.sql
@@ -60,5 +60,5 @@
   {% endif %}
 
   {# Return the unique tags as a list #}
-  {{ return(unique_tags.keys() | list) }}
+  {{ return(unique_tags.keys() | sort | list) }}
 {% endmacro %}


### PR DESCRIPTION
I got the strange results with dbt Fusion. However, if we utilize a dict to unique values, that works.

```
{% macro test_scope() %}
  {% set unique_tags = [] %}

  {% set seeds = [[1, 2, 3], [2, 3, 4], [3, 4, 5]] %}
  {% for seed in seeds %}
    {% do unique_tags.extend(seed) %}
    {% set unique_tags = unique_tags | unique | list %}
    {{ print("inside loop: " ~ unique_tags) }}
  {% endfor %}

  {{ print("outside loop: " ~ unique_tags) }}
{% endmacro %}
```

```
'inside loop: [1, 2, 3]'
'inside loop: [1, 2, 3, 4]'
'inside loop: [1, 2, 3, 4, 5]'
'outside loop: [1, 2, 3]'
```

```
{% macro test_scope3() %}
  {% set unique_tags = {} %}

  {% set seeds = [[1, 2, 3], [2, 3, 4], [3, 4, 5]] %}
  {% for seed in seeds %}
    {% for item in seed %}
      {% do unique_tags.update({item: true}) %}
    {% endfor %}

    {{ print("inside loop: " ~ unique_tags.keys()) }}
  {% endfor %}

  {{ print("outside loop: " ~ unique_tags.keys()) }}
{% endmacro %}
```

```
'inside loop: (1, 2, 3)'
'inside loop: (1, 2, 3, 4)'
'inside loop: (1, 2, 3, 4, 5)'
'outside loop: [1, 2, 3, 4, 5]'
```