### PR TITLE
Add l-diversity generic data test implementation

### DIFF
--- a/.claude/skills/dbt-custom-generic-test/SKILL.md
+++ b/.claude/skills/dbt-custom-generic-test/SKILL.md
@@ -34,11 +34,13 @@ This skill keeps **SKILL.md** short for discovery and puts procedural detail in 
 
 | Concern | Example in repo |
 |--------|-------------------|
-| Generic test + `bigquery__test_*` | [`macros/generic_tests/k_anonymity/k_anonymity.sql`](../../../macros/generic_tests/k_anonymity/k_anonymity.sql) |
+| Generic test + `bigquery__test_*` (k-anonymity) | [`macros/generic_tests/k_anonymity/k_anonymity.sql`](../../../macros/generic_tests/k_anonymity/k_anonymity.sql) |
+| Generic test + `bigquery__test_*` (l-diversity) | [`macros/generic_tests/l_diversity/l_diversity.sql`](../../../macros/generic_tests/l_diversity/l_diversity.sql) |
 | Validation + query SQL | [`k_anonymity_validate_arguments.sql`](../../../macros/generic_tests/k_anonymity/k_anonymity_validate_arguments.sql), [`k_anonymity_query_sql_impl.sql`](../../../macros/generic_tests/k_anonymity/k_anonymity_query_sql_impl.sql) |
 | Macro property docs | [`k_anonymity.yml`](../../../macros/generic_tests/k_anonymity/k_anonymity.yml) (`name: test_k_anonymity`) |
 | Integration fixture + qualified test | [`schema.yml`](../../../integration_tests/models/generic_tests/k_anonymity/schema.yml) (`dbt_data_privacy.k_anonymity`) |
 | Macro unit test (name must not shadow generic test) | [`test_k_anonymity.sql`](../../../integration_tests/macros/tests/generic_tests/test_k_anonymity.sql) |
+| Macro unit test (l-diversity) | [`test_l_diversity.sql`](../../../integration_tests/macros/tests/generic_tests/test_l_diversity.sql) |
 
 ## Constraints specific to dbt-data-privacy
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ But, the implementation can be extended to other warehouses by following the man
 
 ## Generic tests
 
-Custom generic data tests (for example **k_anonymity**), semantics, arguments, and YAML examples are documented in [docs/references/generic_tests.md](docs/references/generic_tests.md).
+Custom generic data tests (**k_anonymity**, **l_diversity**), semantics, arguments, and YAML examples are documented in [docs/references/generic_tests.md](docs/references/generic_tests.md).
 
 ## Macros
 

--- a/docs/references/generic_tests.md
+++ b/docs/references/generic_tests.md
@@ -48,6 +48,65 @@ models:
 
 Otherwise you can pass the same parameters at the top level of the test node (see your dbt version and project flags).
 
+## l_diversity
+
+Validates **distinct l-diversity** on a caller-chosen set of **quasi-identifier** columns and one **sensitive** column: within each distinct tuple of quasi-identifiers, the sensitive column must take **at least `l` distinct values** (`COUNT(DISTINCT)`). This mitigates the **homogeneity attack** on k-anonymous tables (see [k-anonymity](https://en.wikipedia.org/wiki/K-anonymity) and related models). The test uses an **exact** `GROUP BY` check (see [custom generic tests](https://docs.getdbt.com/best-practices/writing-custom-generic-data-tests?version=1.12)). It does not transform data; it only fails if any equivalence class has too few distinct sensitive values.
+
+For microdata-style releases, use **`l_diversity` together with `k_anonymity`**: k limits how rare a QI tuple is; l limits how homogeneous the sensitive attribute is within each tuple class.
+
+The generic test is implemented for **BigQuery only** (`bigquery__test_l_diversity`); there is no `default__` fallback for other adapters.
+
+Macros live under [`macros/generic_tests/l_diversity/`](../../macros/generic_tests/l_diversity/): [`l_diversity.sql`](../../macros/generic_tests/l_diversity/l_diversity.sql) (test + `bigquery__test_l_diversity`), [`l_diversity_resolve_sensitive_column.sql`](../../macros/generic_tests/l_diversity/l_diversity_resolve_sensitive_column.sql), [`l_diversity_validate_arguments.sql`](../../macros/generic_tests/l_diversity/l_diversity_validate_arguments.sql), and [`l_diversity_query_sql_impl.sql`](../../macros/generic_tests/l_diversity/l_diversity_query_sql_impl.sql) (`l_diversity_test_query_sql` and `bigquery__l_diversity_query_sql_impl`).
+
+**Semantics**
+
+- **Pass:** the compiled query returns zero rows.
+- **Fail:** up to `sample_limit` rows are returned. Each row includes the quasi-identifier columns, `group_size`, `distinct_sensitive_count`, and `total_violating_groups` (count of violating classes; repeated on each sampled row). Groups are ordered by smallest `distinct_sensitive_count` first.
+- **NULLs (QI):** standard SQL `GROUP BY` behavior (NULL groups with NULL).
+- **NULLs (sensitive):** `COUNT(DISTINCT sensitive)` does not count NULLs; if all sensitive values in a class are NULL, `distinct_sensitive_count` is 0 and the class fails for any `l >= 1`.
+
+**Arguments**
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `quasi_identifiers` | yes | Non-empty list of column names on the model (no duplicate names). Must not include the sensitive column. |
+| `sensitive_column` | conditional | Model column name for the sensitive attribute. Omit when the test is declared under `columns:`; then dbt supplies `column_name` and that column is used as the sensitive attribute. |
+| `l` | yes | Minimum distinct sensitive count per QI tuple; integer ≥ 1 (practice often uses l ≥ 2). |
+| `sample_limit` | no | Max rows returned on failure; default `50`. |
+| `column_name` | no | Set by dbt when the test is attached at column level; used as the sensitive column when `sensitive_column` is omitted. |
+
+**Compiled SQL (tests and debugging)**
+
+`dbt_data_privacy.l_diversity_test_query_sql(model, quasi_identifiers, sensitive_column, l, sample_limit)` returns the same SQL string the generic test executes after validation. The `sensitive_column` argument must be the **resolved** column name string (as in SQL). It dispatches to BigQuery-specific SQL only.
+
+**Example (model-level `data_tests`)**
+
+When this package is installed as a dependency, qualify the test with the package name (for example `dbt_data_privacy.l_diversity` in YAML).
+
+```yaml
+models:
+  - name: my_release_model
+    data_tests:
+      - dbt_data_privacy.l_diversity:
+          arguments:
+            quasi_identifiers: [age_band, gender, postal_sector]
+            sensitive_column: diagnosis_code
+            l: 3
+            sample_limit: 20
+```
+
+**Example (column-level `data_tests`)**
+
+```yaml
+columns:
+  - name: diagnosis_code
+    data_tests:
+      - dbt_data_privacy.l_diversity:
+          arguments:
+            quasi_identifiers: [age_band, gender, postal_sector]
+            l: 3
+```
+
 ## Data Loss Prevention
 
 COMING SOON

--- a/integration_tests/macros/tests/generic_tests/test_l_diversity.sql
+++ b/integration_tests/macros/tests/generic_tests/test_l_diversity.sql
@@ -1,0 +1,24 @@
+{# Unit tests target l_diversity_test_query_sql (public SQL builder), not the generic test macro. #}
+{% macro test_l_diversity_sql_fragments() %}
+  {{- return(adapter.dispatch("test_l_diversity_sql_fragments", "dbt_data_privacy_integration_tests")()) -}}
+{% endmacro %}
+
+{% macro bigquery__test_l_diversity_sql_fragments() %}
+  {%- set sql = dbt_data_privacy.l_diversity_test_query_sql(
+      ref("example_l_diverse_release"),
+      ["qi_a", "qi_b"],
+      "sensitive",
+      3,
+      10
+  ) -%}
+
+  {% do assert_str_in_value("FROM", sql) %}
+  {% do assert_str_in_value("GROUP BY", sql) %}
+  {% do assert_str_in_value("COUNT(DISTINCT", sql) %}
+  {% do assert_str_in_value("distinct_sensitive_count", sql) %}
+  {% do assert_str_in_value("group_size", sql) %}
+  {% do assert_str_in_value("WHERE distinct_sensitive_count < 3", sql) %}
+  {% do assert_str_in_value("total_violating_groups", sql) %}
+  {% do assert_str_in_value("QUALIFY", sql) %}
+  {% do assert_str_in_value("ROW_NUMBER()", sql) %}
+{% endmacro %}

--- a/integration_tests/macros/tests/test_macros.sql
+++ b/integration_tests/macros/tests/test_macros.sql
@@ -68,5 +68,6 @@
     generic_tests
   #}
   {% do test_k_anonymity_sql_fragments() %}
+  {% do test_l_diversity_sql_fragments() %}
 
 {% endmacro %}

--- a/integration_tests/models/.gitignore
+++ b/integration_tests/models/.gitignore
@@ -1,4 +1,0 @@
-# The '.gitignore' file enables us to ignore generated files by dbt-data-privacy locally.
-# Meanwhile, by removing this file, we can test commiting generaed files easily.
-
-data_analysis_layer/

--- a/integration_tests/models/.gitignore
+++ b/integration_tests/models/.gitignore
@@ -1,0 +1,4 @@
+# The '.gitignore' file enables us to ignore generated files by dbt-data-privacy locally.
+# Meanwhile, by removing this file, we can test commiting generaed files easily.
+
+data_analysis_layer/

--- a/integration_tests/models/generic_tests/l_diversity/example_l_diverse_release.sql
+++ b/integration_tests/models/generic_tests/l_diversity/example_l_diverse_release.sql
@@ -1,0 +1,32 @@
+{{ config(materialized="view") }}
+
+{# Three QI groups; each (qi_a, qi_b) has 5 rows with sensitives S1,S1,S2,S2,S3 => COUNT(DISTINCT sensitive) = 3. #}
+SELECT 'G1' AS qi_a, 'X' AS qi_b, 'S1' AS sensitive
+UNION ALL
+SELECT 'G1' AS qi_a, 'X' AS qi_b, 'S1' AS sensitive
+UNION ALL
+SELECT 'G1' AS qi_a, 'X' AS qi_b, 'S2' AS sensitive
+UNION ALL
+SELECT 'G1' AS qi_a, 'X' AS qi_b, 'S2' AS sensitive
+UNION ALL
+SELECT 'G1' AS qi_a, 'X' AS qi_b, 'S3' AS sensitive
+UNION ALL
+SELECT 'G2' AS qi_a, 'Y' AS qi_b, 'S1' AS sensitive
+UNION ALL
+SELECT 'G2' AS qi_a, 'Y' AS qi_b, 'S1' AS sensitive
+UNION ALL
+SELECT 'G2' AS qi_a, 'Y' AS qi_b, 'S2' AS sensitive
+UNION ALL
+SELECT 'G2' AS qi_a, 'Y' AS qi_b, 'S2' AS sensitive
+UNION ALL
+SELECT 'G2' AS qi_a, 'Y' AS qi_b, 'S3' AS sensitive
+UNION ALL
+SELECT 'G3' AS qi_a, 'Z' AS qi_b, 'S1' AS sensitive
+UNION ALL
+SELECT 'G3' AS qi_a, 'Z' AS qi_b, 'S1' AS sensitive
+UNION ALL
+SELECT 'G3' AS qi_a, 'Z' AS qi_b, 'S2' AS sensitive
+UNION ALL
+SELECT 'G3' AS qi_a, 'Z' AS qi_b, 'S2' AS sensitive
+UNION ALL
+SELECT 'G3' AS qi_a, 'Z' AS qi_b, 'S3' AS sensitive

--- a/integration_tests/models/generic_tests/l_diversity/schema.yml
+++ b/integration_tests/models/generic_tests/l_diversity/schema.yml
@@ -1,0 +1,14 @@
+---
+version: 2
+
+models:
+  - name: example_l_diverse_release
+    description: |
+      Fixture for the l_diversity generic test. Each (qi_a, qi_b) tuple has five rows with three distinct sensitive values.
+    data_tests:
+      - dbt_data_privacy.l_diversity:
+          arguments:
+            quasi_identifiers: [qi_a, qi_b]
+            sensitive_column: sensitive
+            l: 3
+            sample_limit: 10

--- a/macros/generic_tests/l_diversity/l_diversity.sql
+++ b/macros/generic_tests/l_diversity/l_diversity.sql
@@ -1,0 +1,13 @@
+{# Dispatch family test_l_diversity: generic test + BigQuery implementation. #}
+{% test l_diversity(model, column_name=none, quasi_identifiers=none, sensitive_column=none, l=none, sample_limit=50) %}
+  {{ return(adapter.dispatch("test_l_diversity", "dbt_data_privacy")(model, column_name, quasi_identifiers, sensitive_column, l, sample_limit)) }}
+{% endtest %}
+
+{% macro bigquery__test_l_diversity(model, column_name, quasi_identifiers, sensitive_column, l, sample_limit) %}
+  {%- set resolved_sensitive = dbt_data_privacy.l_diversity_resolve_sensitive_column(sensitive_column, column_name) -%}
+  {{- dbt_data_privacy.l_diversity_validate_arguments(quasi_identifiers, resolved_sensitive, l, sample_limit) -}}
+{%- if not execute -%}
+  {{ return("") }}
+{%- endif -%}
+  {{ return(adapter.dispatch("l_diversity_query_sql_impl", "dbt_data_privacy")(model, quasi_identifiers, resolved_sensitive, l, sample_limit)) }}
+{% endmacro %}

--- a/macros/generic_tests/l_diversity/l_diversity.yml
+++ b/macros/generic_tests/l_diversity/l_diversity.yml
@@ -1,0 +1,92 @@
+---
+version: 2
+
+macros:
+  - name: test_l_diversity
+    description: |
+      Generic data test for distinct l-diversity (see l-diversity with k-anonymity, e.g. Wikipedia k-anonymity see-also):
+      within each distinct tuple of quasi_identifiers, the sensitive column must take at least l distinct values
+      (exact COUNT(DISTINCT) on BigQuery only; no default__ implementation). Passes when the compiled query returns
+      zero rows; on failure, returns up to sample_limit violating groups (smallest distinct_sensitive_count first) with
+      total_violating_groups on each row. NULL quasi-identifiers follow standard SQL GROUP BY behavior. NULL sensitive
+      values are excluded from COUNT(DISTINCT), so groups with only NULL sensitives yield distinct_sensitive_count 0
+      and fail for any l >= 1.
+
+      When this package is installed as a dependency, reference the test in YAML as dbt_data_privacy.l_diversity
+      so dbt resolves this macro from the package.
+
+      Use together with k_anonymity when releasing microdata-style tables: k limits re-identification by tuple count;
+      l limits homogeneity of the sensitive attribute within each tuple class.
+    arguments:
+      - name: model
+        type: relation
+        description: The relation under test (ref() / source()).
+      - name: column_name
+        type: column
+        description: |
+          When sensitive_column is omitted, the sensitive attribute defaults to this column name (dbt sets it when the
+          test is declared under columns). Otherwise ignored if sensitive_column is set.
+      - name: quasi_identifiers
+        type: string
+        description: |
+          Non-empty list of column names on the model (YAML list of strings). No duplicate names. Defines equivalence
+          classes for the l-diversity check. Must not include the sensitive column.
+      - name: sensitive_column
+        type: string
+        description: |
+          Optional model column name for the sensitive attribute. If omitted, column_name must be set (column-level
+          test declaration).
+      - name: l
+        type: integer
+        description: |
+          Minimum number of distinct sensitive values per quasi-identifier tuple; must be >= 1. Practice often uses
+          l >= 2.
+      - name: sample_limit
+        type: integer
+        description: |
+          Maximum number of violating groups returned when the test fails (default 50 on the generic test).
+          Smallest distinct_sensitive_count groups are listed first.
+
+  - name: l_diversity_test_query_sql
+    description: |
+      Returns the same SQL string the l_diversity generic test executes at runtime (after argument validation),
+      for macro unit tests, debugging, or documentation. The sensitive_column argument must be the resolved column
+      name on the model (same string that would be used in SQL). Dispatches to bigquery__l_diversity_query_sql_impl only;
+      there is no cross-adapter fallback.
+    arguments:
+      - name: model
+        type: relation
+        description: Target relation (ref() / source()) whose rows are grouped by quasi_identifiers.
+      - name: quasi_identifiers
+        type: string
+        description: Non-empty list of column names defining the quasi-identifier tuple (YAML list of strings).
+      - name: sensitive_column
+        type: string
+        description: Resolved sensitive column name on the model (must not be in quasi_identifiers).
+      - name: l
+        type: integer
+        description: Minimum required COUNT(DISTINCT sensitive) per distinct tuple; must be >= 1.
+      - name: sample_limit
+        type: integer
+        description: Row cap on the outer QUALIFY when violations exist (same semantics as the generic test).
+
+  - name: l_diversity_validate_arguments
+    description: |
+      Validates quasi_identifiers, resolved sensitive column name, l, and sample_limit for the l-diversity test and
+      SQL builder. Raises compiler_error with a clear message if any argument is missing, the wrong type, or invalid
+      (e.g. empty list, duplicate quasi_identifiers, sensitive column listed as a quasi_identifier, l or sample_limit
+      less than 1). Does not render SQL; call l_diversity_test_query_sql or the generic test for executable output.
+    arguments:
+      - name: quasi_identifiers
+        type: string
+        description: |
+          Required. Must be a non-empty list of unique string column names (not a single string).
+      - name: resolved_sensitive
+        type: string
+        description: Required. Non-empty trimmed column name for the sensitive attribute; must not appear in quasi_identifiers.
+      - name: l
+        type: integer
+        description: Required. Coerced to integer; must be >= 1.
+      - name: sample_limit
+        type: integer
+        description: Required. Coerced to integer; must be >= 1.

--- a/macros/generic_tests/l_diversity/l_diversity_query_sql_impl.sql
+++ b/macros/generic_tests/l_diversity/l_diversity_query_sql_impl.sql
@@ -1,0 +1,45 @@
+{# Dispatch family l_diversity_query_sql_impl: public SQL builder + BigQuery implementation. #}
+{% macro l_diversity_test_query_sql(model, quasi_identifiers, sensitive_column, l, sample_limit) %}
+  {{- dbt_data_privacy.l_diversity_validate_arguments(quasi_identifiers, sensitive_column, l, sample_limit) -}}
+  {{ return(adapter.dispatch("l_diversity_query_sql_impl", "dbt_data_privacy")(model, quasi_identifiers, sensitive_column, l, sample_limit)) }}
+{% endmacro %}
+
+{% macro bigquery__l_diversity_query_sql_impl(model, quasi_identifiers, resolved_sensitive, l, sample_limit) %}
+  {%- set l_int = l | int -%}
+  {%- set sample_limit_int = sample_limit | int -%}
+{# Distinct l-diversity: each distinct tuple of quasi_identifiers must have at least l distinct sensitive values. #}
+WITH base AS (
+  SELECT
+    {% for col in quasi_identifiers -%}
+    {{ col }},
+    {%- endfor %}
+    {{ resolved_sensitive }} AS _sensitive
+  FROM {{ model }}
+),
+group_stats AS (
+  SELECT
+    {% for col in quasi_identifiers -%}
+    {{ col }},
+    {%- endfor %}
+    COUNT(*) AS group_size,
+    COUNT(DISTINCT _sensitive) AS distinct_sensitive_count
+  FROM base
+  GROUP BY {% for col in quasi_identifiers -%}{{ col }}{% if not loop.last %}, {% endif %}{%- endfor %}
+),
+violations AS (
+  SELECT
+    *,
+    COUNT(*) OVER () AS total_violating_groups
+  FROM group_stats
+  WHERE distinct_sensitive_count < {{ l_int }}
+)
+SELECT *
+FROM violations
+QUALIFY ROW_NUMBER() OVER (
+  ORDER BY
+    distinct_sensitive_count ASC
+    {% for col in quasi_identifiers -%}
+    , {{ col }} ASC
+    {%- endfor %}
+) <= {{ sample_limit_int }}
+{% endmacro %}

--- a/macros/generic_tests/l_diversity/l_diversity_resolve_sensitive_column.sql
+++ b/macros/generic_tests/l_diversity/l_diversity_resolve_sensitive_column.sql
@@ -1,0 +1,18 @@
+{# Resolve which model column is the sensitive attribute for l-diversity (compile-time only). #}
+{% macro l_diversity_resolve_sensitive_column(sensitive_column, column_name) %}
+  {%- if sensitive_column is not none and sensitive_column is string -%}
+    {%- set s = sensitive_column | trim -%}
+    {%- if s | length > 0 -%}
+      {{ return(s) }}
+    {%- endif -%}
+  {%- endif -%}
+  {%- if column_name is not none and column_name is string -%}
+    {%- set c = column_name | trim -%}
+    {%- if c | length > 0 -%}
+      {{ return(c) }}
+    {%- endif -%}
+  {%- endif -%}
+  {{ exceptions.raise_compiler_error(
+    "l_diversity: set sensitive_column in test arguments, or declare the test under columns: so dbt passes column_name"
+  ) }}
+{% endmacro %}

--- a/macros/generic_tests/l_diversity/l_diversity_validate_arguments.sql
+++ b/macros/generic_tests/l_diversity/l_diversity_validate_arguments.sql
@@ -1,0 +1,48 @@
+{% macro l_diversity_validate_arguments(quasi_identifiers, resolved_sensitive, l, sample_limit) %}
+  {# Required args and shape: list of string column names (not a single string). #}
+  {%- if quasi_identifiers is none -%}
+    {{ exceptions.raise_compiler_error("l_diversity: quasi_identifiers is required") }}
+  {%- elif quasi_identifiers is string -%}
+    {{ exceptions.raise_compiler_error("l_diversity: quasi_identifiers must be a non-empty list of column names") }}
+  {%- elif quasi_identifiers | length == 0 -%}
+    {{ exceptions.raise_compiler_error("l_diversity: quasi_identifiers must be a non-empty list of column names") }}
+  {%- endif -%}
+
+  {%- if resolved_sensitive is none or resolved_sensitive is not string or (resolved_sensitive | trim | length) == 0 -%}
+    {{ exceptions.raise_compiler_error("l_diversity: resolved sensitive column name is missing or empty") }}
+  {%- endif -%}
+  {%- set resolved = resolved_sensitive | trim -%}
+
+  {# Track seen names so GROUP BY semantics stay unambiguous. #}
+  {%- set ns = namespace(uniq=[]) -%}
+  {%- for col in quasi_identifiers -%}
+    {%- if col is not string -%}
+      {{ exceptions.raise_compiler_error("l_diversity: each quasi_identifier must be a string, got " ~ col) }}
+    {%- endif -%}
+    {%- if col in ns.uniq -%}
+      {{ exceptions.raise_compiler_error("l_diversity: duplicate quasi_identifier '" ~ col ~ "'") }}
+    {%- endif -%}
+    {%- set _ = ns.uniq.append(col) -%}
+  {%- endfor -%}
+
+  {%- if resolved in ns.uniq -%}
+    {{ exceptions.raise_compiler_error(
+      "l_diversity: sensitive column '" ~ resolved ~ "' must not appear in quasi_identifiers"
+    ) }}
+  {%- endif -%}
+
+  {# l: minimum COUNT(DISTINCT sensitive) per quasi-identifier tuple. #}
+  {%- if l is none -%}
+    {{ exceptions.raise_compiler_error("l_diversity: l is required") }}
+  {%- endif -%}
+  {%- set l_int = l | int -%}
+  {%- if l_int < 1 -%}
+    {{ exceptions.raise_compiler_error("l_diversity: l must be an integer >= 1") }}
+  {%- endif -%}
+
+  {# Cap rows returned when the test fails (avoids huge result sets). #}
+  {%- set sample_limit_int = sample_limit | int -%}
+  {%- if sample_limit_int < 1 -%}
+    {{ exceptions.raise_compiler_error("l_diversity: sample_limit must be an integer >= 1") }}
+  {%- endif -%}
+{% endmacro %}


### PR DESCRIPTION
Add l-diversity generic data test implementation

- Updated README to include l-diversity in generic tests documentation.
- Enhanced SKILL.md with examples for both k-anonymity and l-diversity.
- Added l-diversity validation and SQL implementation macros.
- Created integration tests for l-diversity, including example data and schema.
- Updated existing macros to support l-diversity functionality.

This commit introduces a new generic data test for l-diversity, complementing the existing k-anonymity test, and enhances documentation accordingly.