### PR TITLE
Format generated data_tests by dbt version for schema YAML

### DIFF
--- a/docs/generate_models.md
+++ b/docs/generate_models.md
@@ -352,6 +352,15 @@ Therefore, it would be good to implement a script like [`integration_tests/scrip
 dbt --quiet run-operation dbt_data_privacy.generate_privacy_protected_models
 ```
 
+The format of generated column `data_tests` depends on the dbt version used to run the macro:
+
+- **dbt 1.10.5 or later**: test parameters are nested under `arguments`, and test options such as `tags`, `severity`, and `where` are nested under `config`. See the [dbt data tests property reference](https://docs.getdbt.com/reference/resource-properties/data-tests).
+- **dbt 1.10.0 through 1.10.4**: test parameters are written at the top level of the test definition, while `tags`, `severity`, and `where` remain under `config`.
+
+When annotating column `data_tests` in source metadata, prefer nesting test options under a `config` block (for example `config: { tags: [...] }`) rather than placing them at the top level alongside macro arguments. The formatter recognizes `tags`, `severity`, and `where` at the top level, but other dbt test config keys should be written under `config` to avoid being emitted as test arguments.
+
+Run the macro with the same dbt version (or newer) as the project that will consume the generated schema YAML, so the output matches what that project expects.
+
 [The pull request](https://github.com/ubie-oss/dbt-data-privacy/pull/49) demonstrates how to generate dbt models.
 We examine the generated `consents` and `users` in the data analysis project.
 

--- a/integration_tests/macros/test_utils/asserts.sql
+++ b/integration_tests/macros/test_utils/asserts.sql
@@ -30,6 +30,14 @@
   {% endif %}
 {% endmacro %}
 
+{% macro assert_str_not_in_value(str, value) %}
+  {% if str in value %}
+    {% do exceptions.raise_compiler_error("FAILED: the string " ~ str ~ " was found in " ~ value) %}
+  {% else %}
+    {% do log("SUCCESS") %}
+  {% endif %}
+{% endmacro %}
+
 {% macro assert_element_in_list(element, list_values) %}
   {% if element not in list_values %}
     {% do exceptions.raise_compiler_error("FAILED: the element " ~ element ~ " was not found in " ~ list_values) %}

--- a/integration_tests/macros/tests/codegen/test_format_data_test_for_schema_v2.sql
+++ b/integration_tests/macros/tests/codegen/test_format_data_test_for_schema_v2.sql
@@ -1,0 +1,303 @@
+{% macro test_format_data_test_for_schema_v2() %}
+  {{- return(adapter.dispatch("test_format_data_test_for_schema_v2", "dbt_data_privacy_integration_tests")()) -}}
+{% endmacro %}
+
+{% macro default__test_format_data_test_for_schema_v2() %}
+  {{ assert_equals(
+      dbt_data_privacy.format_data_test_for_schema_v2('unique'),
+      'unique'
+    ) }}
+
+  {{ assert_dict_equals(
+      dbt_data_privacy._build_modern_data_test(
+        'relationships',
+        {},
+        {
+          'to': 'ref("foo")',
+          'field': 'id',
+        },
+      ),
+      {
+        'relationships': {
+          'arguments': {
+            'to': 'ref("foo")',
+            'field': 'id',
+          },
+        },
+      }
+    ) }}
+
+  {{ assert_dict_equals(
+      dbt_data_privacy._build_legacy_data_test(
+        'relationships',
+        {},
+        {
+          'to': 'ref("foo")',
+          'field': 'id',
+        },
+      ),
+      {
+        'relationships': {
+          'to': 'ref("foo")',
+          'field': 'id',
+        },
+      }
+    ) }}
+
+  {{ assert_dict_equals(
+      dbt_data_privacy._build_modern_data_test(
+        'dbt_utils.expression_is_true',
+        {},
+        {
+          'expression': ">= timestamp('2022-04-07 00:00:00', 'Asia/Tokyo')",
+        },
+      ),
+      {
+        'dbt_utils.expression_is_true': {
+          'arguments': {
+            'expression': ">= timestamp('2022-04-07 00:00:00', 'Asia/Tokyo')",
+          },
+        },
+      }
+    ) }}
+
+  {{ assert_dict_equals(
+      dbt_data_privacy._build_legacy_data_test(
+        'dbt_utils.expression_is_true',
+        {},
+        {
+          'expression': ">= timestamp('2022-04-07 00:00:00', 'Asia/Tokyo')",
+        },
+      ),
+      {
+        'dbt_utils.expression_is_true': {
+          'expression': ">= timestamp('2022-04-07 00:00:00', 'Asia/Tokyo')",
+        },
+      }
+    ) }}
+
+  {{ assert_dict_equals(
+      dbt_data_privacy._build_modern_data_test(
+        'dbt_expectations.expect_column_proportion_of_unique_values_to_be_between',
+        {'tags': ['only_prod']},
+        {
+          'min_value': 0.99,
+          'max_value': 1.0,
+          'row_condition': "DATE(event_time, 'Asia/Tokyo') = CURRENT_DATE('Asia/Tokyo') - 1",
+        },
+      ),
+      {
+        'dbt_expectations.expect_column_proportion_of_unique_values_to_be_between': {
+          'config': {
+            'tags': ['only_prod'],
+          },
+          'arguments': {
+            'min_value': 0.99,
+            'max_value': 1.0,
+            'row_condition': "DATE(event_time, 'Asia/Tokyo') = CURRENT_DATE('Asia/Tokyo') - 1",
+          },
+        },
+      }
+    ) }}
+
+  {{ assert_dict_equals(
+      dbt_data_privacy._build_legacy_data_test(
+        'dbt_expectations.expect_column_proportion_of_unique_values_to_be_between',
+        {'tags': ['only_prod']},
+        {
+          'min_value': 0.99,
+          'max_value': 1.0,
+          'row_condition': "DATE(event_time, 'Asia/Tokyo') = CURRENT_DATE('Asia/Tokyo') - 1",
+        },
+      ),
+      {
+        'dbt_expectations.expect_column_proportion_of_unique_values_to_be_between': {
+          'min_value': 0.99,
+          'max_value': 1.0,
+          'row_condition': "DATE(event_time, 'Asia/Tokyo') = CURRENT_DATE('Asia/Tokyo') - 1",
+          'config': {
+            'tags': ['only_prod'],
+          },
+        },
+      }
+    ) }}
+
+  {{ assert_dict_equals(
+      dbt_data_privacy._build_modern_data_test(
+        'relationships',
+        {'tags': ['only_prod']},
+        {
+          'to': 'ref("foo")',
+          'field': 'id',
+        },
+      ),
+      {
+        'relationships': {
+          'config': {
+            'tags': ['only_prod'],
+          },
+          'arguments': {
+            'to': 'ref("foo")',
+            'field': 'id',
+          },
+        },
+      }
+    ) }}
+
+  {{ assert_dict_equals(
+      dbt_data_privacy._build_legacy_data_test(
+        'relationships',
+        {'tags': ['only_prod']},
+        {
+          'to': 'ref("foo")',
+          'field': 'id',
+        },
+      ),
+      {
+        'relationships': {
+          'to': 'ref("foo")',
+          'field': 'id',
+          'config': {
+            'tags': ['only_prod'],
+          },
+        },
+      }
+    ) }}
+
+  {{ assert_dict_equals(
+      dbt_data_privacy._build_modern_data_test(
+        'accepted_values',
+        {'where': "order_date = current_date"},
+        {'values': ['placed', 'shipped']},
+        'unexpected_order_status_today',
+      ),
+      {
+        'accepted_values': {
+          'name': 'unexpected_order_status_today',
+          'config': {
+            'where': "order_date = current_date",
+          },
+          'arguments': {
+            'values': ['placed', 'shipped'],
+          },
+        },
+      }
+    ) }}
+
+  {{ assert_dict_equals(
+      dbt_data_privacy.format_data_test_for_schema_v2({
+        'relationships': {
+          'to': 'ref("foo")',
+          'field': 'id',
+        },
+      }),
+      dbt_data_privacy._build_modern_data_test(
+        'relationships',
+        {},
+        {
+          'to': 'ref("foo")',
+          'field': 'id',
+        },
+      ) if dbt_data_privacy.is_dbt_at_least('1.10.5') else dbt_data_privacy._build_legacy_data_test(
+        'relationships',
+        {},
+        {
+          'to': 'ref("foo")',
+          'field': 'id',
+        },
+      )
+    ) }}
+
+  {{ assert_dict_equals(
+      dbt_data_privacy.format_data_test_for_schema_v2({
+        'relationships': {
+          'arguments': {},
+          'to': 'ref("foo")',
+          'field': 'id',
+        },
+      }),
+      dbt_data_privacy._build_modern_data_test(
+        'relationships',
+        {},
+        {
+          'to': 'ref("foo")',
+          'field': 'id',
+        },
+      ) if dbt_data_privacy.is_dbt_at_least('1.10.5') else dbt_data_privacy._build_legacy_data_test(
+        'relationships',
+        {},
+        {
+          'to': 'ref("foo")',
+          'field': 'id',
+        },
+      )
+    ) }}
+
+  {{ assert_dict_equals(
+      dbt_data_privacy.format_data_test_for_schema_v2({
+        'relationships': {
+          'arguments': {
+            'to': 'ref("foo")',
+            'field': 'id',
+          },
+          'config': {
+            'tags': ['only_prod'],
+          },
+        },
+      }),
+      dbt_data_privacy._build_modern_data_test(
+        'relationships',
+        {'tags': ['only_prod']},
+        {
+          'to': 'ref("foo")',
+          'field': 'id',
+        },
+      ) if dbt_data_privacy.is_dbt_at_least('1.10.5') else dbt_data_privacy._build_legacy_data_test(
+        'relationships',
+        {'tags': ['only_prod']},
+        {
+          'to': 'ref("foo")',
+          'field': 'id',
+        },
+      )
+    ) }}
+
+  {{ assert_dict_equals(
+      dbt_data_privacy.format_data_test_for_schema_v2({
+        'accepted_values': {
+          'severity': 'warn',
+          'values': ['placed', 'shipped'],
+        },
+      }),
+      dbt_data_privacy._build_modern_data_test(
+        'accepted_values',
+        {'severity': 'warn'},
+        {'values': ['placed', 'shipped']},
+      ) if dbt_data_privacy.is_dbt_at_least('1.10.5') else dbt_data_privacy._build_legacy_data_test(
+        'accepted_values',
+        {'severity': 'warn'},
+        {'values': ['placed', 'shipped']},
+      )
+    ) }}
+
+  {{ assert_dict_equals(
+      dbt_data_privacy.format_data_test_for_schema_v2({
+        'accepted_values': {
+          'name': 'unexpected_order_status_today',
+          'values': ['placed', 'shipped'],
+          'where': "order_date = current_date",
+        },
+      }),
+      dbt_data_privacy._build_modern_data_test(
+        'accepted_values',
+        {'where': "order_date = current_date"},
+        {'values': ['placed', 'shipped']},
+        'unexpected_order_status_today',
+      ) if dbt_data_privacy.is_dbt_at_least('1.10.5') else dbt_data_privacy._build_legacy_data_test(
+        'accepted_values',
+        {'where': "order_date = current_date"},
+        {'values': ['placed', 'shipped']},
+        'unexpected_order_status_today',
+      )
+    ) }}
+{% endmacro %}

--- a/integration_tests/macros/tests/codegen/test_generate_secured_model_schema_v2_data_tests.sql
+++ b/integration_tests/macros/tests/codegen/test_generate_secured_model_schema_v2_data_tests.sql
@@ -1,0 +1,74 @@
+{% macro test_generate_secured_model_schema_v2_data_tests() %}
+  {{- return(adapter.dispatch("test_generate_secured_model_schema_v2_data_tests", "dbt_data_privacy_integration_tests")()) -}}
+{% endmacro %}
+
+{% macro default__test_generate_secured_model_schema_v2_data_tests() %}
+  {%- set result = dbt_data_privacy.generate_secured_model_schema_v2(
+      objective="data_analysis",
+      name="test_project__test_dataset__test_table",
+      database="test-project",
+      schema="test_dataset",
+      alias="test_table",
+      description="Sample description",
+      columns={
+        "person_id": {
+          "name": "person_id",
+          "description": "Person ID",
+          "config": {
+            "meta": {
+              "data_privacy": {
+                "level": "confidential",
+                "test_project__test_dataset__test_table": {
+                  "data_tests": [
+                    {
+                      "relationships": {
+                        "to": 'ref("test_project__test_dataset__users")',
+                        "field": "id",
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+        "log_id": {
+          "name": "log_id",
+          "description": "Log ID",
+          "config": {
+            "meta": {
+              "data_privacy": {
+                "level": "internal",
+                "test_project__test_dataset__test_table": {
+                  "data_tests": [
+                    {
+                      "dbt_expectations.expect_column_proportion_of_unique_values_to_be_between": {
+                        "min_value": 0.99,
+                        "max_value": 1.0,
+                        "row_condition": "DATE(event_time, 'Asia/Tokyo') = CURRENT_DATE('Asia/Tokyo') - 1",
+                        "tags": ["only_prod"],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+      tags=["tag1"],
+      labels={},
+    ) -%}
+
+  {%- set normalized_result = result | replace(' ', '') | trim -%}
+  {%- if dbt_data_privacy.is_dbt_at_least('1.10.5') -%}
+    {{ assert_str_in_value("'arguments':{'to':", normalized_result) }}
+  {%- else -%}
+    {{ assert_str_not_in_value("'arguments':{'to':", normalized_result) }}
+    {{ assert_str_in_value("'relationships':{'to':", normalized_result) }}
+  {%- endif -%}
+  {{ assert_str_in_value("'field':'id'", normalized_result) }}
+  {{ assert_str_in_value("'config':{'tags':['only_prod']}", normalized_result) }}
+  {{ assert_str_in_value("'min_value':0.99", normalized_result) }}
+  {{ assert_str_in_value("'row_condition':", normalized_result) }}
+{% endmacro %}

--- a/integration_tests/macros/tests/test_macros.sql
+++ b/integration_tests/macros/tests/test_macros.sql
@@ -13,6 +13,7 @@
     utils
   #}
   {% do test_deep_copy_dict() %}
+  {% do test_is_dbt_at_least() %}
   {% do test_get_data_privacy_configs() %}
   {% do test_get_data_privacy_objectives() %}
   {% do test_get_data_privacy_config_by_objective() %}
@@ -55,6 +56,8 @@
     codegen
   #}
   {% do test_format_model_config() %}
+  {% do test_format_data_test_for_schema_v2() %}
+  {% do test_generate_secured_model_schema_v2_data_tests() %}
   {% do test_generate_secured_model_schema_v2() %}
   {% do test_generate_privacy_protected_model_sql() %}
 

--- a/integration_tests/macros/tests/utils/test_is_dbt_at_least.sql
+++ b/integration_tests/macros/tests/utils/test_is_dbt_at_least.sql
@@ -1,0 +1,13 @@
+{% macro test_is_dbt_at_least() %}
+  {{- return(adapter.dispatch("test_is_dbt_at_least", "dbt_data_privacy_integration_tests")()) -}}
+{% endmacro %}
+
+{% macro default__test_is_dbt_at_least() %}
+  {{ assert_true(dbt_data_privacy.parse_version_part('10rc1') == 10) }}
+  {{ assert_false(dbt_data_privacy.is_version_at_least('1.10.4', '1.10.5')) }}
+  {{ assert_true(dbt_data_privacy.is_version_at_least('1.10.5', '1.10.5')) }}
+  {{ assert_true(dbt_data_privacy.is_version_at_least('1.10.5-rc1', '1.10.5')) }}
+  {{ assert_true(dbt_data_privacy.is_version_at_least('1.11.0', '1.10.5')) }}
+  {{ assert_true(dbt_data_privacy.is_version_at_least('2.0.0', '1.10.5')) }}
+  {{ assert_false(dbt_data_privacy.is_version_at_least('1.10', '1.10.5')) }}
+{% endmacro %}

--- a/macros/codegen/format_data_test_for_schema_v2.sql
+++ b/macros/codegen/format_data_test_for_schema_v2.sql
@@ -1,0 +1,116 @@
+{% macro _normalize_data_test_for_schema_v2(data_test) %}
+  {%- if data_test is string or data_test is not mapping -%}
+    {{- return(none) -}}
+  {%- endif -%}
+
+  {%- set test_names = data_test.keys() | list -%}
+  {%- if test_names | length != 1 -%}
+    {{- return(none) -}}
+  {%- endif -%}
+
+  {%- set test_name = test_names[0] -%}
+  {%- set test_config = data_test[test_name] -%}
+  {%- if test_config is not mapping -%}
+    {{- return(none) -}}
+  {%- endif -%}
+
+  {#- Top-level keys treated as test config, not macro arguments -#}
+  {%- set config_keys = ['tags', 'severity', 'where'] -%}
+  {%- set ns = namespace(config={}, arguments={}, name=none) -%}
+
+  {%- if test_config.get('arguments') is mapping -%}
+    {%- set ns.arguments = dbt_data_privacy.deep_copy_dict(test_config.arguments) -%}
+    {%- if test_config.get('config') is mapping -%}
+      {%- set ns.config = dbt_data_privacy.deep_copy_dict(test_config.config) -%}
+    {%- endif -%}
+    {%- if test_config.get('name') is not none -%}
+      {%- set ns.name = test_config.name -%}
+    {%- endif -%}
+    {%- for key in config_keys -%}
+      {%- if key in test_config and key not in ns.config -%}
+        {%- do ns.config.update({key: test_config[key]}) -%}
+      {%- endif -%}
+    {%- endfor -%}
+    {%- for key, value in test_config.items() -%}
+      {%- if key in ['config', 'name', 'arguments'] or key in config_keys -%}
+        {# already handled #}
+      {%- elif key not in ns.arguments -%}
+        {%- do ns.arguments.update({key: value}) -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- else -%}
+    {%- if test_config.get('config') is mapping -%}
+      {%- set ns.config = dbt_data_privacy.deep_copy_dict(test_config.config) -%}
+    {%- endif -%}
+    {%- if test_config.get('name') is not none -%}
+      {%- set ns.name = test_config.name -%}
+    {%- endif -%}
+    {%- for key, value in test_config.items() -%}
+      {%- if key == 'config' -%}
+        {# already handled #}
+      {%- elif key == 'name' -%}
+        {# already handled #}
+      {%- elif key in config_keys -%}
+        {%- do ns.config.update({key: value}) -%}
+      {%- elif key != 'arguments' -%}
+        {%- do ns.arguments.update({key: value}) -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+
+  {{- return({
+      'test_name': test_name,
+      'config': ns.config,
+      'arguments': ns.arguments,
+      'name': ns.name,
+    }) -}}
+{% endmacro %}
+
+{% macro _build_modern_data_test(test_name, config, arguments, name=none) %}
+  {%- set formatted_test = {} -%}
+  {%- if name is not none -%}
+    {%- do formatted_test.update({'name': name}) -%}
+  {%- endif -%}
+  {%- if config | length > 0 -%}
+    {%- do formatted_test.update({'config': config}) -%}
+  {%- endif -%}
+  {%- if arguments | length > 0 -%}
+    {%- do formatted_test.update({'arguments': arguments}) -%}
+  {%- endif -%}
+  {{- return({test_name: formatted_test}) -}}
+{% endmacro %}
+
+{% macro _build_legacy_data_test(test_name, config, arguments, name=none) %}
+  {%- set formatted_test = {} -%}
+  {%- if name is not none -%}
+    {%- do formatted_test.update({'name': name}) -%}
+  {%- endif -%}
+  {%- do formatted_test.update(arguments) -%}
+  {%- if config | length > 0 -%}
+    {%- do formatted_test.update({'config': config}) -%}
+  {%- endif -%}
+  {{- return({test_name: formatted_test}) -}}
+{% endmacro %}
+
+{% macro format_data_test_for_schema_v2(data_test) %}
+  {%- set normalized = dbt_data_privacy._normalize_data_test_for_schema_v2(data_test) -%}
+  {%- if normalized is none -%}
+    {{- return(data_test) -}}
+  {%- endif -%}
+
+  {%- if dbt_data_privacy.is_dbt_at_least('1.10.5') -%}
+    {{- return(dbt_data_privacy._build_modern_data_test(
+        normalized.test_name,
+        normalized.config,
+        normalized.arguments,
+        normalized.name
+      )) -}}
+  {%- else -%}
+    {{- return(dbt_data_privacy._build_legacy_data_test(
+        normalized.test_name,
+        normalized.config,
+        normalized.arguments,
+        normalized.name
+      )) -}}
+  {%- endif -%}
+{% endmacro %}

--- a/macros/codegen/generate_secured_model_schema_v2.sql
+++ b/macros/codegen/generate_secured_model_schema_v2.sql
@@ -90,7 +90,7 @@ models:
         {%- set data_tests = column_meta.data_privacy[name].get('data_tests', [])
             + column_meta.data_privacy[name].get('tests', []) %}
         data_tests: {%- for data_test in data_tests %}
-          - {{ data_test }}
+          - {{ dbt_data_privacy.format_data_test_for_schema_v2(data_test) }}
         {%- endfor %}
         {%- endif %}
     {%- endfor %}

--- a/macros/codegen/generate_secured_model_schema_v2_legacy.sql
+++ b/macros/codegen/generate_secured_model_schema_v2_legacy.sql
@@ -88,7 +88,7 @@ models:
         {%- set data_tests = column_meta.data_privacy[name].get('data_tests', [])
             + column_meta.data_privacy[name].get('tests', []) %}
         data_tests: {%- for data_test in data_tests %}
-          - {{ data_test }}
+          - {{ dbt_data_privacy.format_data_test_for_schema_v2(data_test) }}
         {%- endfor %}
         {%- endif %}
     {%- endfor %}

--- a/macros/public/generate_privacy_protected_models.yml
+++ b/macros/public/generate_privacy_protected_models.yml
@@ -24,6 +24,10 @@ macros:
         type: boolean
         description: |-
           If true, prints detailed information about the generated models. Defaults to true.
+      - name: legacy_schema
+        type: boolean
+        description: |-
+          If true, generate schema YAML with legacy top-level tags/meta. If false, use dbt 1.10+ config blocks. Defaults to true.
     description: |
       This macro generates privacy-protected models based on the specified criteria such as unique IDs, original file paths, tags, and additional labels.
       It leverages the `generate_privacy_protected_model` macro to create models that adhere to data privacy configurations defined in the project.

--- a/macros/utils/is_dbt_at_least.sql
+++ b/macros/utils/is_dbt_at_least.sql
@@ -1,0 +1,41 @@
+{% macro parse_version_part(part) %}
+  {%- set clean_part = part.split('-')[0] -%}
+  {%- set match = modules.re.match('^(\d+)', clean_part) -%}
+  {%- if match is none -%}
+    {%- do exceptions.raise_compiler_error(
+        'dbt_data_privacy.parse_version_part: unable to parse version part "' ~ part ~ '"'
+      ) -%}
+  {%- endif -%}
+  {{- return(match.group(1) | int) -}}
+{% endmacro %}
+
+{#-
+  Pre-release suffixes (for example 1.10.5-rc1) are stripped before comparison,
+  so release candidates at the same numeric version are treated as supported.
+-#}
+{% macro is_version_at_least(current_version, minimum_version) %}
+  {%- set current_parts = current_version.split('.') -%}
+  {%- set minimum_parts = minimum_version.split('.') -%}
+  {%- set max_length = [current_parts | length, minimum_parts | length] | max -%}
+
+  {%- for i in range(max_length) -%}
+    {%- set current_part = 0 -%}
+    {%- set minimum_part = 0 -%}
+    {%- if i < current_parts | length -%}
+      {%- set current_part = dbt_data_privacy.parse_version_part(current_parts[i]) -%}
+    {%- endif -%}
+    {%- if i < minimum_parts | length -%}
+      {%- set minimum_part = dbt_data_privacy.parse_version_part(minimum_parts[i]) -%}
+    {%- endif -%}
+    {%- if current_part > minimum_part -%}
+      {{- return(true) -}}
+    {%- elif current_part < minimum_part -%}
+      {{- return(false) -}}
+    {%- endif -%}
+  {%- endfor -%}
+  {{- return(true) -}}
+{% endmacro %}
+
+{% macro is_dbt_at_least(minimum_version) %}
+  {{- return(dbt_data_privacy.is_version_at_least(dbt_version, minimum_version)) -}}
+{% endmacro %}


### PR DESCRIPTION
## Summary

- Add `format_data_test_for_schema_v2` to normalize column `data_tests` when generating secured model schema YAML via `generate_privacy_protected_models`.
- On **dbt 1.10.5+**, emit test macro parameters under `arguments` and test options (`tags`, `severity`, `where`) under `config`, matching the [dbt data tests property reference](https://docs.getdbt.com/reference/resource-properties/data-tests).
- On **dbt 1.10.0–1.10.4**, flatten test parameters to the top level while keeping test options under `config`.
- Introduce `is_dbt_at_least` / `is_version_at_least` utilities to select the output format at `run-operation` time based on `dbt_version`.
- Document version-dependent output in `docs/generate_models.md` and document the existing `legacy_schema` argument on `generate_privacy_protected_models`.

## Test plan

- [x] Unit tests for version comparison (`test_is_dbt_at_least`)
- [x] Unit tests for modern/legacy data test formatting and schema generation (`test_format_data_test_for_schema_v2`, `test_generate_secured_model_schema_v2_data_tests`)
- [ ] CI unit tests pass (`make run-unit-tests` / GitHub Actions unit-tests workflow)


Made with [Cursor](https://cursor.com)